### PR TITLE
better issue number search

### DIFF
--- a/search.php
+++ b/search.php
@@ -394,7 +394,7 @@ class Search
                 case '#':
                     $issues = Workflow::requestApi('/repos/'.$parts[0].'/issues?sort=updated&state=all');
                     foreach ($issues as $issue) {
-                        Workflow::addItemIfMatches(Item::create()
+                        Workflow::addItemIfMatchesIssue(Item::create()
                             ->title($issue->title)
                             ->comparator($parts[0].' #'.$issue->number.' '.$issue->title)
                             ->subtitle('#'.$issue->number)

--- a/workflow.php
+++ b/workflow.php
@@ -398,6 +398,13 @@ class Workflow
         }
     }
 
+    public static function addItemIfMatchesIssue(Item $item)
+    {
+        if ($item->match(self::$query.' ')) {
+            self::$items[] = $item;
+        }
+    }
+
     public static function addItem(Item $item)
     {
         self::$items[] = $item;


### PR DESCRIPTION
Issue number search works better now. For instance: gh org/repo #10 will find the issue number 10, instead of lots of other issues with the number '10' in it. 